### PR TITLE
Remove deep thinking tool from tools modal

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,5 +1,4 @@
 /* main.js — versión simplificada
- * - Sin o3
  * - Solo gpt-5-nano (rápido)
  * - Un solo archivo (sin imports)
  * - KV usando kv.del() para borrar

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,15 +126,6 @@
           </button>
         </div>
 
-        <!-- Pensamiento profundo -->
-        <label class="flex items-center gap-3 py-2">
-          <input id="deepToggle" type="checkbox" class="h-4 w-4">
-          <div>
-            <div class="text-sm font-medium">Pensamiento profundo (o3-mini)</div>
-            <div class="text-xs text-sub">Más razonamiento, puede tardar un poco más.</div>
-          </div>
-        </label>
-
         <!-- Subir imagen -->
         <div class="mt-3">
           <button id="uploadImgBtn" class="w-full rounded-lg border border-line bg-pane hover:bg-black/40 px-3 py-2 text-sm">


### PR DESCRIPTION
## Summary
- remove "Pensamiento profundo" option from tools modal
- drop outdated deep reasoning reference in main.js comment

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a97cead01c832682afdc8632c97911