### PR TITLE
Refine upgrade UI placement

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -68,7 +68,6 @@ const cancelDeleteBtn = $("#cancelDeleteBtn");
 const confirmDeleteBtn = $("#confirmDeleteBtn");
 
 // Billing / Planes
-const plansBtn = $("#plansBtn");
 const plansModal = $("#plansModal");
 const plansOverlay = $("#plansOverlay");
 const closePlans = $("#closePlans");
@@ -589,7 +588,6 @@ window.addEventListener("DOMContentLoaded", async () => {
   newChatBtn?.addEventListener("click", newChat);
 
   // Planes / Suscripciones
-  plansBtn?.addEventListener("click", openPlansModal);
   openProCTA?.addEventListener("click", () => console.info("TODO: integrar Stripe"));
   plansOverlay?.addEventListener("click", closePlansModal);
   closePlans?.addEventListener("click", closePlansModal);

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,8 +50,7 @@
     </header>
 
     <!-- Upgrade banner -->
-    <div id="upgradeBanner" class="hidden bg-ink border-b border-line text-sm text-center px-4 py-2 flex items-center justify-center gap-2">
-      <span>Estás en Starter. Consigue memoria y adjuntos de mayor tamaño con Pro.</span>
+    <div id="upgradeBanner" class="hidden bg-ink border-b border-line px-4 py-2 flex justify-center">
       <button data-action="upgrade" class="btn-primary text-xs">Mejorar a Pro</button>
     </div>
 
@@ -61,7 +60,6 @@
     <div class="px-4 py-3 border-b border-line">
       <div class="flex items-center gap-2">
         <div class="font-semibold flex-1">Tus chats</div>
-        <button id="plansBtn" class="px-2 py-1 text-xs rounded-lg bg-white text-black font-medium hover:bg-white/90 border border-line">Pro / Suscripciones</button>
         <button id="prefsBtn" class="px-2 py-1 text-xs rounded-lg bg-white text-black font-medium hover:bg-white/90">Personalización</button>
         <button id="newChatBtn" class="px-2 py-1 text-xs border border-line rounded-lg hover:bg-pane">Nuevo</button>
         <button id="closeSidebarBtn" class="p-2 rounded-lg border border-line hover:bg-pane" aria-label="Cerrar">


### PR DESCRIPTION
## Summary
- Center top "Mejorar a Pro" banner button and drop Starter text
- Remove upgrade link from chat sidebar and related JS

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a98477c7088326bdf09984e80aa46b