### PR TITLE
feat: enforce daily usage limits with Puter

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -116,7 +116,7 @@
           </button>
         </form>
 
-        <div id="usageHint" class="mt-2 text-right text-xs text-sub">0/20 mensajes hoy</div>
+        <div id="usageHint" class="mt-2 text-right text-xs text-sub">0/30 mensajes hoy</div>
 
         <!-- Previsualización de adjunto -->
         <div id="attachRow" class="mt-2 hidden">
@@ -222,7 +222,8 @@
           <div class="p-4 border border-line rounded-2xl">
             <h3 class="font-medium mb-2">Starter</h3>
             <ul class="text-sm space-y-1 mb-4 list-disc list-inside">
-              <li>20 mensajes/día</li>
+              <li>30 mensajes/día</li>
+              <li>2 imágenes/día</li>
               <li>Sin memoria avanzada</li>
               <li>Adjuntos ≤1MB</li>
             </ul>


### PR DESCRIPTION
## Summary
- track Starter vs Pro plans in Puter KV and enforce message/image quotas
- expose helpers for forcing plan or usage and refresh limits on focus
- update Starter plan description with 30 messages and 2 images per day

## Testing
- `node --check static/main.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a98ab85cd08326aecf30e8ca595b0f